### PR TITLE
Updated for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ How to use
 Example of a simple script that runs mysql's shell
 
 ```python
-from flask.ext.dbshell import DbShell
+from flask_dbshell import DbShell
 
 
 def main():
     dbshell = DbShell('mysql://scott:tiger@server/dbname')
     dbshell.run_shell()
-    
+
 
 if __name__ == '__main__':
     main()
@@ -41,8 +41,8 @@ Example of use with Flask-Script:
 
 ```python
 from flask import Flask
-from flask.ext.script import Manager
-from flask.ext.dbshell import DbShell
+from flask_script import Manager
+from flask_dbshell import DbShell
 
 
 class DevConfig(object):
@@ -53,12 +53,10 @@ app = Flask(__name__)
 app.config.from_object(DevConfig)
 manager = Manager(app)
 
+manager.add_command('dbshell', DbShell())
 
-@manager.command
-def dbshell():
-    shell = DbShell(url=app.config['DATABASE_URI'])
-    shell.run_shell()
-
+# or if your database url string is not at app.config['DATABASE_URI']
+manager.add_command('dbshell', DbShell(url_config_key='SQLALCHEMY_DATABASE_URI'))
 
 if __name__ == "__main__":
     manager.run()
@@ -68,4 +66,4 @@ if __name__ == "__main__":
 Python versions supported
 -------------------------
 
-Tested with 2.6.x and 2.7.x
+Tested with 2.6.x, 2.7.x, and 3.6.x

--- a/example/manage.py
+++ b/example/manage.py
@@ -1,8 +1,8 @@
 # manage.py
 
 from flask import Flask
-from flask.ext.script import Manager
-from flask.ext.dbshell import DbShell
+from flask_script import Manager
+from flask_dbshell import DbShell
 
 
 class DevConfig(object):
@@ -13,12 +13,10 @@ app = Flask(__name__)
 app.config.from_object(DevConfig)
 manager = Manager(app)
 
+manager.add_command('dbshell', DbShell())
 
-@manager.command
-def dbshell():
-    shell = DbShell(url=app.config['DATABASE_URI'])
-    shell.run_shell()
-
+# or if your database url string is not at app.config['DATABASE_URI']
+manager.add_command('dbshell', DbShell(url_config_key='SQLALCHEMY_DATABASE_URI'))
 
 if __name__ == "__main__":
     manager.run()

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,1 +1,1 @@
-Flask-Script==0.6.7
+Flask-Script==2.0.5

--- a/flask_dbshell/backends/__init__.py
+++ b/flask_dbshell/backends/__init__.py
@@ -1,4 +1,5 @@
 import subprocess
+from importlib import import_module
 
 
 def load_backend(dburl):
@@ -14,10 +15,11 @@ def load_backend(dburl):
 
     if dburl.backend is None:
         raise ValueError('database backend is not specified')
-    module_name = dburl.backend
+    module_name = 'flask_dbshell.backends.{}'.format(dburl.backend)
     class_name = dburl.backend.capitalize() + 'Backend'
     try:
-        module = __import__(module_name, globals(), locals())
+        print(f'module_name: {module_name}')
+        module = import_module(module_name)
     except ImportError as e:
         raise UnknownBackendError('Unknown backend: "%s"' % dburl.backend)
     backend_cls = getattr(module, class_name)

--- a/flask_dbshell/backends/postgresql.py
+++ b/flask_dbshell/backends/postgresql.py
@@ -6,6 +6,10 @@ class PostgresqlBackend(BaseBackend):
     def compile_command(self):
         parts = []
         parts.append('psql')
+        connection_string = self._dburl.get_connection_string()
+        if connection_string:
+            parts.append(connection_string)
+            return parts
         if self._dburl.host:
             parts.append('--host=%s' % self._dburl.host)
         if self._dburl.port:

--- a/flask_dbshell/compatibility.py
+++ b/flask_dbshell/compatibility.py
@@ -1,0 +1,16 @@
+try:
+    dict.iteritems
+except AttributeError:
+    # Python 3
+    def itervalues(d):
+        return iter(d.values())
+
+    def iteritems(d):
+        return iter(d.items())
+else:
+    # Python 2
+    def itervalues(d):
+        return d.itervalues()
+
+    def iteritems(d):
+        return d.iteritems()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='Flask-DbShell',
-    version='1.0',
+    version='2.0',
     url='http://github.com/ffeast/flask-dbshell/',
     license='BSD',
     author='ffeast',
@@ -19,6 +19,7 @@ setup(
     platforms='any',
     install_requires=[
         'Flask',
+        'Flask-Script',
     ],
     tests_require=[
         'mock>=1.0.1'


### PR DESCRIPTION
Also

- converted examples away from the deprecated flask.ext pattern
- updated to support manager.add_command
- added support for calling psql with connection-string argument, to work around “option '--password' doesn't allow an argument” error